### PR TITLE
feat: add 3 input vars related with s3 buckets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,7 @@ module "s3_log_storage_bucket" {
 
   kms_master_key_arn                 = local.kms_key_arn
   sse_algorithm                      = "aws:kms"
-  versioning_enabled                 = false
+  versioning_enabled                 = var.versioning_enabled
   expiration_days                    = var.expiration_days
   glacier_transition_days            = var.glacier_transition_days
   lifecycle_prefix                   = var.lifecycle_prefix
@@ -183,6 +183,8 @@ module "s3_log_storage_bucket" {
   bucket_notifications_prefix        = var.bucket_notifications_prefix
   access_log_bucket_name             = var.access_log_bucket_name
   access_log_bucket_prefix           = var.access_log_bucket_prefix
+  s3_object_ownership                = var.s3_object_ownership
+  acl                                = var.acl
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -117,3 +117,21 @@ variable "kms_key_arn" {
   description = "ARN of KMS that will be used for s3 bucket encryption."
   default     = ""
 }
+
+variable "versioning_enabled" {
+  type        = bool
+  description = "Enable object versioning, keeping multiple variants of an object in the same bucket"
+  default     = true
+}
+
+variable "s3_object_ownership" {
+  type        = string
+  default     = "BucketOwnerPreferred"
+  description = "Specifies the S3 object ownership control. Valid values are `ObjectWriter`, `BucketOwnerPreferred`, and 'BucketOwnerEnforced'."
+}
+
+variable "acl" {
+  type        = string
+  description = "The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services"
+  default     = "log-delivery-write"
+}


### PR DESCRIPTION
Similar to: https://github.com/ManagedKube/terraform-aws-vpc-flow-logs-s3-bucket?ref=0.17.0 but without the version bump on s3 log module to make it backwards compatible.